### PR TITLE
Allow foldMapOf to work with empty traversals

### DIFF
--- a/src/folds.js
+++ b/src/folds.js
@@ -1,38 +1,29 @@
 var R = require('ramda')
 var curry = R.curry
 var compose = R.compose
-var Const = require('./internal/_const')
+var _Const = require('./internal/_const')
 var monoids = require('./internal/_monoids')
 
 var _getValue = function(x) { return x.value }
 
-var foldMap = curry(function(f, fldable) {
-  return fldable.reduce(function(acc, x) {
-    var r = f(x)
-    acc = acc || r.empty()
-    return acc.concat(r)
-  }, null)
-})
 
-var folded = curry(function(f, x) {
-  return compose(Const, foldMap(compose(_getValue, f)))(x)
-})
-
-var foldMapOf = curry(function(l, f, x) {
-  return compose(_getValue, l(compose(Const, f)))(x)
+var foldMapOf = curry(function(l, empty, toM, x) {
+  var Const = _Const(empty)
+  return _getValue(l.call(Const, function(a) {
+    return Const(toM(a))
+  })(x))
 })
 
 // Example folds. Needs monoidal types. Ramda fantasy?
 var anyOf = curry(function(l, f, xs) {
-  return compose(_getValue, foldMapOf(l, compose(monoids.Any, f)))(xs)
+  return compose(_getValue, foldMapOf(l, monoids.Any.empty(), compose(monoids.Any, f)))(xs)
 })
 
 var sumOf = curry(function(l, xs) {
-  return compose(_getValue, foldMapOf(l, monoids.Sum))(xs)
+  return compose(_getValue, foldMapOf(l, monoids.Sum.empty(), monoids.Sum))(xs)
 })
 
 module.exports = {
-  folded: folded,
   foldMapOf: foldMapOf,
   anyOf: anyOf,
   sumOf: sumOf

--- a/src/internal/_const.js
+++ b/src/internal/_const.js
@@ -1,9 +1,18 @@
-module.exports = function Const(x) {
-  return {
-    type: 'Const',
-    value: x,
-    map: function(f) { return this },
-    ap: function(other) { return Const(x.concat(other.value)) }
+module.exports = function _Const(empty) {
+  function Const(x) {
+    return {
+      type:  'Const',
+      value: x,
+      map:   function (f) {
+        return this
+      },
+      ap:    function (other) {
+        return Const(x.concat(other.value))
+      }
+    }
   }
+  Const.of = function(_) {
+    return Const(empty)
+  }
+  return Const
 }
-

--- a/src/internal/_identity.js
+++ b/src/internal/_identity.js
@@ -1,4 +1,4 @@
-module.exports = function Identity(x) {
+function Identity(x) {
   return {
     type: 'Identity',
     value: x,
@@ -9,3 +9,7 @@ module.exports = function Identity(x) {
     }
   }
 }
+
+Identity.of = Identity
+
+module.exports = Identity

--- a/src/internal/_monoids.js
+++ b/src/internal/_monoids.js
@@ -2,18 +2,18 @@ function Sum(x) {
   return {
     type: 'Sum',
     value: x,
-    concat: function(s){ return Sum(x + s.value) },
-    empty: function() {return Sum(0) }
+    concat: function(s){ return Sum(x + s.value) }
   }
 }
+Sum.empty = function() {return Sum(0) }
 
 function Any(x) {
   return {
     type: 'Any',
     value: x,
-    concat: function(s){ return Any(x || s.value) },
-    empty: function() {return Any(false) }
+    concat: function(s){ return Any(x || s.value) }
   }
 }
+Any.empty = function() {return Any(false) }
 
 module.exports = {Sum: Sum, Any: Any}

--- a/src/over.js
+++ b/src/over.js
@@ -26,7 +26,7 @@ var Identity = require('./internal/_identity')
  *      R.over(headLens, R.toUpper, ['foo', 'bar', 'baz']); //=> ['FOO', 'bar', 'baz']
  */
 module.exports = curry(function over(lens, f, x) {
-  return lens(function(y) {
+  return lens.call(Identity, function(y) {
     return Identity(f(y));
   })(x).value;
 });

--- a/src/traversals.js
+++ b/src/traversals.js
@@ -5,14 +5,15 @@ var traverse = R.traverse
 var map = R.map
 var Identity = require('./internal/_identity')
 
-var _getValue = function(x) { return x.value; }
+var _getValue = function(x) { return x.value }
 
 var mapped = curry(function(f, x) {
-  return Identity(map(compose(_getValue, f), x));
+  return Identity(map(compose(_getValue, f), x))
 })
-var traversed = curry(function(of, f, x) {
-  return Identity(traverse(of, compose(_getValue, f), x));
-})
+
+var traversed = function(f) {
+  return traverse(this.of, f)
+}
 
 module.exports = {
   mapped: mapped,

--- a/src/view.js
+++ b/src/view.js
@@ -1,7 +1,6 @@
 var R = require('ramda')
 var curry = R.curry
-
-var Const = require('./internal/_const')
+var Const = require('./internal/_const')([])
 
 
 /**
@@ -26,5 +25,7 @@ var Const = require('./internal/_const')
  *      R.view(xLens, {x: 4, y: 2});  //=> 4
  */
 module.exports = curry(function view(lens, x) {
-  return lens(Const)(x).value;
+  return lens.call(Const, function(a) {
+    return Const([a])
+  })(x).value[0]
 });


### PR DESCRIPTION
Fixes #6

As [previously mentioned](https://github.com/ramda/ramda-lens/issues/6#issuecomment-243742528), it's a bit of a novel approach to solving the problem by using the `this` binding to store the applicative instance, but I can't _think_ of any major problems that we'd encounter by adopting it ... worst case scenario we can remove it like previously planned.
