### PR TITLE
Add listOf

### DIFF
--- a/src/folds.js
+++ b/src/folds.js
@@ -1,5 +1,6 @@
 var curry = require('ramda/src/curry')
 var compose = require('ramda/src/compose')
+var of = require('ramda/src/of');
 var _Const = require('./internal/_const')
 var monoids = require('./internal/_monoids')
 
@@ -22,8 +23,13 @@ var sumOf = curry(function(l, xs) {
   return compose(_getValue, foldMapOf(l, monoids.Sum.empty(), monoids.Sum))(xs)
 })
 
+var listOf = curry(function(l, xs) {
+  return foldMapOf(l, [], of, xs)
+})
+
 module.exports = {
   foldMapOf: foldMapOf,
   anyOf: anyOf,
-  sumOf: sumOf
+  sumOf: sumOf,
+  listOf: listOf
 }

--- a/test/test.js
+++ b/test/test.js
@@ -14,6 +14,7 @@ const objIpair = L.objIpair
 const foldMapOf = L.foldMapOf
 const anyOf = L.anyOf
 const sumOf = L.sumOf
+const listOf = L.listOf
 
 const Identity = require('../src/internal/_identity')
 const monoids = require('../src/internal/_monoids')
@@ -142,6 +143,12 @@ describe("Lenses", function() {
       var any = anyOf(traversed)
       var res = any(function(x){ return x > 4 }, [1,2,3])
       assert.equal(res, false)
+    })
+
+    it('works with listOf', function() {
+      var unnest = listOf(compose(traversed, lensProp('x'), traversed))
+      var res = unnest([{ x: [1, 2] }, { x: [3, 4] }, { x: [5, 6] }])
+      assert.deepEqual(res, [1, 2, 3, 4, 5, 6])
     })
 
     it('works with an empty list', function() {


### PR DESCRIPTION
This allows for collecting multiple targets of a traversal into a list.

``` js
listOf(compose(traversed, lensProp('x'), traversed), [{ x: [1, 2] }, { x: [3, 4] }, { x: [5, 6] }])
//=> [1, 2, 3, 4, 5, 6]
```
