### PR TITLE
Add traverseOf

### DIFF
--- a/src/internal/_identity.js
+++ b/src/internal/_identity.js
@@ -1,3 +1,5 @@
+var equals = require('ramda/src/equals');
+
 function Identity(x) {
   return {
     type: 'Identity',
@@ -6,6 +8,9 @@ function Identity(x) {
     ap: function(other) { return other.map(x) },
     sequence: function(of) {
       return x.map(Identity)
+    },
+    equals: function(other) {
+      return other.type == 'Identity' && equals(x, other.value)
     }
   }
 }

--- a/src/traversals.js
+++ b/src/traversals.js
@@ -14,7 +14,12 @@ var traversed = function(f) {
   return traverse(this.of, f)
 }
 
+var traverseOf = curry(function(lens, ofFn, f, target) {
+  return lens.call({ of: ofFn }, f)(target)
+})
+
 module.exports = {
   mapped: mapped,
-  traversed: traversed
+  traversed: traversed,
+  traverseOf: traverseOf
 }

--- a/test/test.js
+++ b/test/test.js
@@ -9,6 +9,7 @@ const view = L.view
 const over = L.over
 const mapped = L.mapped
 const traversed = L.traversed
+const traverseOf = L.traverseOf
 const from = L.from
 const objIpair = L.objIpair
 const foldMapOf = L.foldMapOf
@@ -82,6 +83,18 @@ describe("Lenses", function() {
       const result = over(traversed, trav_fn, Identity(2))
       const expected = Identity(3)
       assert.deepEqual(result.value, expected.value)
+    })
+
+    it('with applicatives via traverseOf', function() {
+      const everyId = compose(traversed, lensProp('x'));
+      const result = traverseOf(
+        everyId,
+        Identity,
+        function(x) { return Identity(x + 1) },
+        [{ x: 1 }, { x: 2 }, { x: 3 }]
+      )
+      const expected = Identity([{ x: 2 }, { x: 3 }, { x: 4 }])
+      assert(expected.equals(result))
     })
 
     it('traversals compose', function() {


### PR DESCRIPTION
This adds the `traverseOf` function to allow the target of a lens or traversal to have some applicative action run against it.

Relates to #13 (note: I've swapped the argument order of `traverseOf` from the example I posted in the other issue)

Ping @DrBoolean 
