### PR TITLE
feat(lens): add utils for further lens utilization

### DIFF
--- a/src/lens.js
+++ b/src/lens.js
@@ -4,6 +4,7 @@ var curry = require('ramda/src/curry')
 var view = require('ramda/src/view')
 var pipe = require('ramda/src/pipe')
 var equals = require('ramda/src/equals')
+var defaultTo = require('ramda/src/defaultTo')
 
 var lensEq = curry(function(_lens, val, obj) {
   return pipe(view(_lens), equals(val))(obj)
@@ -13,10 +14,15 @@ var lensSatisfies = curry(function(pred, _lens, obj) {
   return pipe(view(_lens), pred, equals(true))(obj)
 });
 
+var viewOr = curry(function (defaultValue, _lens, obj) {
+  return pipe(view(_lens), defaultTo(defaultValue))(obj)
+});
+
 module.exports = {
   lens: lens,
   set: set,
   view: require('./view'),
+  viewOr: viewOr,
   over: require('./over'),
   lensEq: lensEq,
   lensSatisfies: lensSatisfies

--- a/src/lens.js
+++ b/src/lens.js
@@ -1,10 +1,23 @@
 var set = require('ramda/src/set')
 var lens = require('ramda/src/lens')
+var curry = require('ramda/src/curry')
+var view = require('ramda/src/view')
+var pipe = require('ramda/src/pipe')
+var equals = require('ramda/src/equals')
 
+var lensEq = curry(function(_lens, val, obj) {
+  return pipe(view(_lens), equals(val))(obj)
+});
+
+var lensSatisfies = curry(function(pred, _lens, obj) {
+  return pipe(view(_lens), pred, equals(true))(obj)
+});
 
 module.exports = {
   lens: lens,
   set: set,
   view: require('./view'),
-  over: require('./over')
+  over: require('./over'),
+  lensEq: lensEq,
+  lensSatisfies: lensSatisfies
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,12 +1,15 @@
-const assert = require("assert")
+const assert = require('assert')
 const L = require('../index')
-const R = require("ramda")
+const R = require('ramda')
 const compose = R.compose
 const lensProp = R.lensProp
 const lensIndex = R.lensIndex
+const equals = R.equals
 const set = L.set
 const view = L.view
 const over = L.over
+const lensEq = L.lensEq
+const lensSatisfies = L.lensSatisfies
 const mapped = L.mapped
 const traversed = L.traversed
 const traverseOf = L.traverseOf
@@ -35,7 +38,7 @@ describe("Lenses", function() {
   const zip = lensProp('zip')
 
 
-  describe("Set/View/Over", function() {
+  describe("Set/View/Over/LensEq/LensSatisfies", function() {
     const firstStreet = compose(_0, addresses, _0, street)
 
     it('gets the value', function() {
@@ -55,6 +58,22 @@ describe("Lenses", function() {
       assert.equal('92 OAK ST.', res[0].addresses[0].street)
       assert.equal('393 Post Ave.', res[1].addresses[0].street)
       assert.equal('92 Oak St.', users[0].addresses[0].street)
+    })
+
+    it('test if object has a specific value on provided lens', function() {
+      const res = lensEq(firstStreet, '92 Oak St.', users)
+      assert.ok(res)
+
+      const resCurried = lensEq(firstStreet)('92 Oak St.')(users)
+      assert.ok(resCurried)
+    })
+
+    it('test if specified object property at lens satisfies the given predicate', function() {
+      const res = lensSatisfies(equals('92 Oak St.'), firstStreet, users)
+      assert.ok(res)
+
+      const resCurried = lensSatisfies(equals('92 Oak St.'))(firstStreet)(users)
+      assert.ok(resCurried)
     })
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -39,7 +39,7 @@ describe("Lenses", function() {
   const zip = lensProp('zip')
 
 
-  describe("Set/View/Over/LensEq/LensSatisfies", function() {
+  describe("Set/View/ViewOr/Over/LensEq/LensSatisfies", function() {
     const firstStreet = compose(_0, addresses, _0, street)
 
     it('gets the value', function() {

--- a/test/test.js
+++ b/test/test.js
@@ -7,6 +7,7 @@ const lensIndex = R.lensIndex
 const equals = R.equals
 const set = L.set
 const view = L.view
+const viewOr = L.viewOr
 const over = L.over
 const lensEq = L.lensEq
 const lensSatisfies = L.lensSatisfies
@@ -74,6 +75,17 @@ describe("Lenses", function() {
 
       const resCurried = lensSatisfies(equals('92 Oak St.'))(firstStreet)(users)
       assert.ok(resCurried)
+    })
+
+    it('test "view" of the given data structure, determined by the given lens with default value', function() {
+      const res = viewOr('default street', firstStreet, users)
+      assert.equal('92 Oak St.', res)
+
+      const resDefault = viewOr('default street', lensProp('non-existing-prop'), users)
+      assert.equal('default street', resDefault)
+
+      const resCurried = viewOr('default street')(firstStreet)(users)
+      assert.equal('92 Oak St.', resCurried)
     })
   })
 


### PR DESCRIPTION
Added:
- lensEq
- lensSatisfies
- viewOr

This pull requests add in my opinion utils that many people implement them self, because they don't exist in ramda, nor ramda-lens. I tried to be consistent with existing codestyle as much as I could.